### PR TITLE
fix bug in dockerfile, fix bug in deploy configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ WORKDIR /plugin
 
 COPY --from=builder /go/src/github.com/vapor-ware/synse-emulator-plugin/build/emulator ./plugin
 COPY config.yml .
-COPY config/ ./config/
+COPY config/proto /etc/synse/plugin/config/proto
 
 CMD ["./plugin"]

--- a/deploy/docker/config/tcp/config.yml
+++ b/deploy/docker/config/tcp/config.yml
@@ -4,5 +4,3 @@ debug: true
 network:
   type: tcp
   address: ":5001"
-settings:
-  loop_delay: 1000

--- a/deploy/docker/config/unix/config.yml
+++ b/deploy/docker/config/unix/config.yml
@@ -4,5 +4,3 @@ debug: true
 network:
   type: unix
   address: emulator.sock
-settings:
-  loop_delay: 1000


### PR DESCRIPTION
noticed two bugs here:
1. the deploy configs still had `loop_delay` under the `settings` option, which is no longer correct in the current SDK version (read and write loop interval now default to 1s, so the behavior stays the same here).
2. the prototype configs were just copied to the `./config/` path, which is not one of the default search paths. that means the user would always have to override the prototype config path. this copies the prototype configs into the default search path.