### PR TITLE
Updates to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
 FROM iron/go:dev as builder
 WORKDIR /go/src/github.com/vapor-ware/synse-emulator-plugin
 COPY . .
-RUN make build GIT_TAG="" GIT_COMMIT=""
+
+RUN make build CGO_ENABLED=0
 
 
-FROM iron/go
-MAINTAINER Vapor IO <eng@vapor.io>
+FROM scratch
 
-WORKDIR /plugin
+LABEL maintainer="vapor@vapor.io"
 
 COPY --from=builder /go/src/github.com/vapor-ware/synse-emulator-plugin/build/emulator ./plugin
-COPY config.yml .
+COPY config.yml   /etc/synse/plugin/config.yml
 COPY config/proto /etc/synse/plugin/config/proto
 
-CMD ["./plugin"]
+EXPOSE 5001
+
+ENTRYPOINT ["./plugin"]


### PR DESCRIPTION
This PR does a few things:
- removes the GIT_TAG and GIT_COMMIT overrides which were preventing those values from being picked up
- removes MAINTAINER (deprecated) keyword in favor of labels
- uses `scratch` as the base image
  - this requires CGO_ENABLED=0 to be set on build

The first two are just minor things, the last is sorta experimental work for minimizing/hardening the container. This setup appears to work just fine for the tests I've done. If no other problems show up, it may be good to apply this pattern elsewhere, if applicable.