### PR TITLE
attempt to fix ci vendoring issue causing release failure

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -24,6 +24,7 @@ pipeline {
       agent {
         docker {
           image 'vaporio/golang:1.11'
+          reuseNode true
         }
       }
       steps {
@@ -50,6 +51,7 @@ pipeline {
       agent {
         docker {
           image 'vaporio/golang:1.11'
+          reuseNode true
         }
       }
       steps {
@@ -90,6 +92,7 @@ pipeline {
       agent {
         docker {
           image 'vaporio/golang:1.11'
+          reuseNode true
         }
       }
       when {

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 PLUGIN_NAME    := emulator
-PLUGIN_VERSION := 2.4.0
+PLUGIN_VERSION := 2.4.1
 IMAGE_NAME     := vaporio/emulator-plugin
 
 # In CI, git commit is CIRCLE_SHA1 and git tag


### PR DESCRIPTION
I use the `reuseNode: true` in other plugin CI pipelines, I'm pretty sure that was what fixed the vendoring issue...


also bump version in preparation for retrying the release