### PR TITLE
Update Lock/Led devices for device.GUID instead of device.ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 PLUGIN_NAME    := emulator
-PLUGIN_VERSION := 2.4.2
+PLUGIN_VERSION := 2.4.3
 IMAGE_NAME     := vaporio/emulator-plugin
 
 # In CI, git commit is CIRCLE_SHA1 and git tag

--- a/pkg/devices/airflow.go
+++ b/pkg/devices/airflow.go
@@ -22,7 +22,7 @@ func airflowRead(device *sdk.Device) ([]*sdk.Reading, error) {
 	var min = -100
 	var max = 100
 
-	dState, ok := deviceState[device.ID()]
+	dState, ok := deviceState[device.GUID()]
 	if ok {
 		if _, ok := dState[MIN]; ok {
 			min = dState[MIN].(int)
@@ -70,9 +70,9 @@ func airflowWrite(device *sdk.Device, data *sdk.WriteData) error {
 		if err != nil {
 			return err
 		}
-		dataMap, ok := deviceState[device.ID()]
+		dataMap, ok := deviceState[device.GUID()]
 		if !ok {
-			deviceState[device.ID()] = map[string]interface{}{MIN: min}
+			deviceState[device.GUID()] = map[string]interface{}{MIN: min}
 		} else {
 			dataMap[MIN] = min
 		}
@@ -85,9 +85,9 @@ func airflowWrite(device *sdk.Device, data *sdk.WriteData) error {
 		if err != nil {
 			return err
 		}
-		dataMap, ok := deviceState[device.ID()]
+		dataMap, ok := deviceState[device.GUID()]
 		if !ok {
-			deviceState[device.ID()] = map[string]interface{}{MAX: max}
+			deviceState[device.GUID()] = map[string]interface{}{MAX: max}
 		} else {
 			dataMap[MAX] = max
 		}

--- a/pkg/devices/humidity.go
+++ b/pkg/devices/humidity.go
@@ -22,7 +22,7 @@ func humidityRead(device *sdk.Device) ([]*sdk.Reading, error) {
 	var min = 0
 	var max = 100
 
-	dState, ok := deviceState[device.ID()]
+	dState, ok := deviceState[device.GUID()]
 	if ok {
 		if _, ok := dState[MIN]; ok {
 			min = dState[MIN].(int)
@@ -76,9 +76,9 @@ func humidityWrite(device *sdk.Device, data *sdk.WriteData) error {
 		if err != nil {
 			return err
 		}
-		dataMap, ok := deviceState[device.ID()]
+		dataMap, ok := deviceState[device.GUID()]
 		if !ok {
-			deviceState[device.ID()] = map[string]interface{}{MIN: min}
+			deviceState[device.GUID()] = map[string]interface{}{MIN: min}
 		} else {
 			dataMap[MIN] = min
 		}
@@ -91,9 +91,9 @@ func humidityWrite(device *sdk.Device, data *sdk.WriteData) error {
 		if err != nil {
 			return err
 		}
-		dataMap, ok := deviceState[device.ID()]
+		dataMap, ok := deviceState[device.GUID()]
 		if !ok {
-			deviceState[device.ID()] = map[string]interface{}{MAX: max}
+			deviceState[device.GUID()] = map[string]interface{}{MAX: max}
 		} else {
 			dataMap[MAX] = max
 		}

--- a/pkg/devices/led.go
+++ b/pkg/devices/led.go
@@ -25,7 +25,7 @@ var LED = sdk.DeviceHandler{
 func ledRead(device *sdk.Device) ([]*sdk.Reading, error) {
 	var state, color string
 
-	dState, ok := deviceState[device.ID()]
+	dState, ok := deviceState[device.GUID()]
 
 	if ok {
 		if _, ok := dState["color"]; ok {
@@ -85,32 +85,32 @@ func ledWrite(device *sdk.Device, data *sdk.WriteData) error { // nolint: gocycl
 			return fmt.Errorf("color value should be a 3-byte (RGB) hex string")
 		}
 
-		dState, ok := deviceState[device.ID()]
+		dState, ok := deviceState[device.GUID()]
 		if !ok {
-			deviceState[device.ID()] = map[string]interface{}{"color": string(raw)}
+			deviceState[device.GUID()] = map[string]interface{}{"color": string(raw)}
 		} else {
 			dState["color"] = string(raw)
 		}
 
 	} else if action == "state" {
 		cmd := string(raw)
-		dState, ok := deviceState[device.ID()]
+		dState, ok := deviceState[device.GUID()]
 
 		if cmd == stateOn {
 			if !ok {
-				deviceState[device.ID()] = map[string]interface{}{"state": stateOn}
+				deviceState[device.GUID()] = map[string]interface{}{"state": stateOn}
 			} else {
 				dState["state"] = stateOn
 			}
 		} else if cmd == stateOff {
 			if !ok {
-				deviceState[device.ID()] = map[string]interface{}{"state": stateOff}
+				deviceState[device.GUID()] = map[string]interface{}{"state": stateOff}
 			} else {
 				dState["state"] = stateOff
 			}
 		} else if cmd == stateBlink {
 			if !ok {
-				deviceState[device.ID()] = map[string]interface{}{"state": stateBlink}
+				deviceState[device.GUID()] = map[string]interface{}{"state": stateBlink}
 			} else {
 				dState["state"] = stateBlink
 			}

--- a/pkg/devices/lock.go
+++ b/pkg/devices/lock.go
@@ -40,7 +40,7 @@ func lockRead(device *sdk.Device) ([]*sdk.Reading, error) {
 
 	var lockState string
 
-	dState, ok := deviceState[device.ID()]
+	dState, ok := deviceState[device.GUID()]
 
 	if ok {
 		if _, ok := dState["lockState"]; ok {
@@ -69,25 +69,25 @@ func lockWrite(device *sdk.Device, data *sdk.WriteData) error {
 	mux.Lock()
 	defer mux.Unlock()
 
-	dState, ok := deviceState[device.ID()]
+	dState, ok := deviceState[device.GUID()]
 
 	switch action := data.Action; action {
 	case actionLock:
 		if !ok {
-			deviceState[device.ID()] = map[string]interface{}{"lockState": stateLock}
+			deviceState[device.GUID()] = map[string]interface{}{"lockState": stateLock}
 		} else {
 			dState["lockState"] = stateLock
 		}
 	case actionUnlock:
 		if !ok {
-			deviceState[device.ID()] = map[string]interface{}{"lockState": stateUnlock}
+			deviceState[device.GUID()] = map[string]interface{}{"lockState": stateUnlock}
 		} else {
 			dState["lockState"] = stateUnlock
 		}
 	case actionPulseUnlock:
 		// Unlock the device for 5 seconds then lock it.
 		if !ok {
-			deviceState[device.ID()] = map[string]interface{}{"lockState": stateUnlock}
+			deviceState[device.GUID()] = map[string]interface{}{"lockState": stateUnlock}
 		} else {
 			dState["lockState"] = stateUnlock
 		}
@@ -99,7 +99,7 @@ func lockWrite(device *sdk.Device, data *sdk.WriteData) error {
 			defer mux.Unlock()
 
 			if !ok {
-				deviceState[device.ID()] = map[string]interface{}{"lockState": stateLock}
+				deviceState[device.GUID()] = map[string]interface{}{"lockState": stateLock}
 			} else {
 				dState["lockState"] = stateLock
 			}

--- a/pkg/devices/pressure.go
+++ b/pkg/devices/pressure.go
@@ -22,7 +22,7 @@ func pressureRead(device *sdk.Device) ([]*sdk.Reading, error) {
 	var min = -5
 	var max = 5
 
-	dState, ok := deviceState[device.ID()]
+	dState, ok := deviceState[device.GUID()]
 	if ok {
 		if _, ok := dState[MIN]; ok {
 			min = dState[MIN].(int)
@@ -70,9 +70,9 @@ func pressureWrite(device *sdk.Device, data *sdk.WriteData) error {
 		if err != nil {
 			return err
 		}
-		dataMap, ok := deviceState[device.ID()]
+		dataMap, ok := deviceState[device.GUID()]
 		if !ok {
-			deviceState[device.ID()] = map[string]interface{}{MIN: min}
+			deviceState[device.GUID()] = map[string]interface{}{MIN: min}
 		} else {
 			dataMap[MIN] = min
 		}
@@ -85,9 +85,9 @@ func pressureWrite(device *sdk.Device, data *sdk.WriteData) error {
 		if err != nil {
 			return err
 		}
-		dataMap, ok := deviceState[device.ID()]
+		dataMap, ok := deviceState[device.GUID()]
 		if !ok {
-			deviceState[device.ID()] = map[string]interface{}{MAX: max}
+			deviceState[device.GUID()] = map[string]interface{}{MAX: max}
 		} else {
 			dataMap[MAX] = max
 		}

--- a/pkg/devices/temperature.go
+++ b/pkg/devices/temperature.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/vapor-ware/synse-emulator-plugin/pkg/utils"
 	"github.com/vapor-ware/synse-sdk/sdk"
 )
@@ -40,12 +39,6 @@ func temperatureRead(device *sdk.Device) ([]*sdk.Reading, error) {
 	if min > max {
 		max = min + 1
 	}
-
-	logrus.WithFields(logrus.Fields{
-		"device": device.ID(),
-		"min":    min,
-		"max":    max,
-	}).Info("reading temp")
 
 	temperature, err := device.GetOutput("temperature").MakeReading(utils.RandIntInRange(min, max))
 	if err != nil {

--- a/pkg/devices/temperature.go
+++ b/pkg/devices/temperature.go
@@ -22,7 +22,7 @@ func temperatureRead(device *sdk.Device) ([]*sdk.Reading, error) {
 	var min = 0
 	var max = 100
 
-	dState, ok := deviceState[device.ID()]
+	dState, ok := deviceState[device.GUID()]
 	if ok {
 		if _, ok := dState[MIN]; ok {
 			min = dState[MIN].(int)
@@ -70,9 +70,9 @@ func temperatureWrite(device *sdk.Device, data *sdk.WriteData) error {
 		if err != nil {
 			return err
 		}
-		dataMap, ok := deviceState[device.ID()]
+		dataMap, ok := deviceState[device.GUID()]
 		if !ok {
-			deviceState[device.ID()] = map[string]interface{}{MIN: min}
+			deviceState[device.GUID()] = map[string]interface{}{MIN: min}
 		} else {
 			dataMap[MIN] = min
 		}
@@ -85,9 +85,9 @@ func temperatureWrite(device *sdk.Device, data *sdk.WriteData) error {
 		if err != nil {
 			return err
 		}
-		dataMap, ok := deviceState[device.ID()]
+		dataMap, ok := deviceState[device.GUID()]
 		if !ok {
-			deviceState[device.ID()] = map[string]interface{}{MAX: max}
+			deviceState[device.GUID()] = map[string]interface{}{MAX: max}
 		} else {
 			dataMap[MAX] = max
 		}


### PR DESCRIPTION
- The emulator will mass-assign devices when using just the device.ID,
the current state of synse-v2-plugins require the guid in order to
ensure its using a serialized identifier for the device being
modified/read.

editors note: i'm not sure if the makefile is the only place i need to bump the version number, lmk if thats incorrect.