### PR TITLE
change lock output from state to status

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ set for that field.
 | pressure | An output type for pressure readings. | Pa | 3 | - |
 | led.state | An output type for LED on/off state. | - | - | - |
 | led.color | An output type for LED color. | - | - | - |
-| lock.state | An output type for lock state. | - | - | - |
+| lock.status | An output type for lock status. | - | - | - |
 
 
 ### Device Handlers

--- a/config/device/lock.yaml
+++ b/config/device/lock.yaml
@@ -10,7 +10,7 @@ devices:
     metadata:
       model: emul8-lock
     outputs:
-      - type: lock.state
+      - type: lock.status
     instances:
       - info: Synse Door Lock
         location: r1vec

--- a/pkg/outputs/outputs.go
+++ b/pkg/outputs/outputs.go
@@ -63,8 +63,8 @@ var (
 		},
 	}
 
-	// LockState is the output type for Lock state readings (locked/unlocked_electrically).
-	LockState = sdk.OutputType{
-		Name: "lock.state",
+	// LockStatus is the output type for Lock status readings (locked/unlocked_electrically).
+	LockStatus = sdk.OutputType{
+		Name: "lock.status",
 	}
 )

--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -21,7 +21,7 @@ func MakePlugin() *sdk.Plugin {
 		&outputs.LedState,
 		&outputs.Pressure,
 		&outputs.Temperature,
-		&outputs.LockState,
+		&outputs.LockStatus,
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
https://github.com/vapor-ware/management-api/issues/67

**Note**: This would require a change to any emulator configurations which specify locks, following the pattern:

```diff
    outputs:
-      - type: lock.state
+      - type: lock.status
```