### PR TITLE
[pipeline] - docker login before gorel

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -69,7 +69,9 @@ pipeline {
       steps {
         script {
           docker.image('vaporio/jenkins-agent-golang:latest').inside('-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -e GITHUB_TOKEN=$GITHUB_TOKEN -v $WORKSPACE:$PROJ_PATH --group-add docker') {
-            sh 'cd ${PROJ_PATH} && goreleaser release --rm-dist'
+            withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+              sh 'cd ${PROJ_PATH} && goreleaser release --rm-dist'
+            }
           }
         }
       }


### PR DESCRIPTION
- Confirmed with tag 2.4.5-login.

https://build.vio.sh/blue/organizations/jenkins/vapor-ware%2Fsynse-emulator-plugin/detail/2.4.5-login/1/pipeline

closes #44 