### PR TITLE
fix bug where unsupported action leads to write success

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 PLUGIN_NAME    := emulator
-PLUGIN_VERSION := 3.0.0-alpha.4
+PLUGIN_VERSION := 3.0.0-alpha.5
 IMAGE_NAME     := vaporio/emulator-plugin
 BIN_NAME       := synse-emulator-plugin
 

--- a/pkg/devices/common.go
+++ b/pkg/devices/common.go
@@ -38,6 +38,8 @@ func minMaxCurrentWrite(device *sdk.Device, data *sdk.WriteData) error {
 		emitter.WithUpperBound(v)
 	case CURRENT:
 		emitter.Set(v)
+	default:
+		return fmt.Errorf("unsupported write action: %v", data.Action)
 	}
 	return nil
 }

--- a/pkg/devices/fan.go
+++ b/pkg/devices/fan.go
@@ -41,6 +41,8 @@ func fanWrite(device *sdk.Device, data *sdk.WriteData) error {
 	switch data.Action {
 	case "speed":
 		emitter.Set(v)
+	default:
+		return fmt.Errorf("unsupport write action: %v", data.Action)
 	}
 	return nil
 }

--- a/pkg/devices/led.go
+++ b/pkg/devices/led.go
@@ -64,6 +64,8 @@ func ledWrite(device *sdk.Device, data *sdk.WriteData) error {
 		default:
 			return fmt.Errorf("unsupported command for state action: %v", cmd)
 		}
+	default:
+		return fmt.Errorf("unsupport write action: %v", data.Action)
 	}
 	return nil
 }


### PR DESCRIPTION
- fixes a bug where action checks could fall through if the value is unsupported, leading the write transaction to finish as OK since it returns nil.
- bumps to v3.0.0-alpha.5