### PR TITLE
bump golang image versions to 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder Image
 #
-FROM vaporio/golang:1.11 as builder
+FROM vaporio/golang:1.13 as builder
 
 #
 # Final Image


### PR DESCRIPTION
This PR:
- bumps the version of the `vaporio/golang` image used in the Dockerfile from 1.11 (deprecated) to 1.13

Fixes #70