### PR TITLE
various updates to CI config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
   - -X github.com/vapor-ware/synse-sdk/sdk.BuildDate={{ .Date }}
   - -X github.com/vapor-ware/synse-sdk/sdk.GitCommit={{ .ShortCommit }}
   - -X github.com/vapor-ware/synse-sdk/sdk.GitTag={{ .Tag }}
-  - -X github.com/vapor-ware/synse-sdk/sdk.GoVersion={{ .Env.GOVERSION }}
+  - -X github.com/vapor-ware/synse-sdk/sdk.GoVersion={{ .Env.GOLANG_VERSION }}
   - -X github.com/vapor-ware/synse-sdk/sdk.PluginVersion={{ .Version }}
   goos:
   - linux

--- a/.jenkins
+++ b/.jenkins
@@ -3,12 +3,11 @@
 pipeline {
 
   agent {
-   label 'golang-next'
+    label 'golang-next'
   }
 
   environment {
     IMAGE_NAME = 'vaporio/emulator-plugin'
-    GOVERSION = '1.12'
   }
 
   stages {
@@ -55,8 +54,7 @@ pipeline {
 
     stage('Tagged Release') {
       when {
-        // example matches: 1.2.3, 1.2.3-dev
-        tag pattern: '(0|[1-9]*)\\.(0|[1-9]*)\\.(0|[1-9]*)(-(\\S*))?$', comparator: "REGEXP"
+        buildingTag()
       }
       agent {
         label 'golang-alpha'


### PR DESCRIPTION
This PR:
- fixes a block indentation
- removes the GOVERSION env variable.. we need this for goreleaser, but I believe that env is set in the agent golang container (@lazypower correct me if I'm wrong here)
- replaces the tag match regex with the simpler `buildingTag` directive