### PR TITLE
run goreleaser in debug mode in CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -31,7 +31,7 @@ pipeline {
       }
       steps {
         container('golang') {
-          sh 'goreleaser release --snapshot --skip-publish --rm-dist'
+          sh 'goreleaser release --debug --snapshot --skip-publish --rm-dist'
         }
       }
     }
@@ -65,7 +65,7 @@ pipeline {
       steps {
         container('golang') {
           withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
-            sh 'goreleaser release --rm-dist'
+            sh 'goreleaser release --debug --rm-dist'
           }
         }
       }

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GIT_TAG        ?= $(shell git describe --tags 2> /dev/null || true)
 BUILD_DATE     := $(shell date -u +%Y-%m-%dT%T 2> /dev/null)
 GO_VERSION     := $(shell go version | awk '{ print $$3 }')
 
-PKG_CTX := github.com/vapor-ware/synse-emulator-plugin/vendor/github.com/vapor-ware/synse-sdk/sdk
+PKG_CTX := github.com/vapor-ware/synse-sdk/sdk
 LDFLAGS := -w \
 	-X ${PKG_CTX}.BuildDate=${BUILD_DATE} \
 	-X ${PKG_CTX}.GitCommit=${GIT_COMMIT} \


### PR DESCRIPTION
This PR:
- updates CI config to run goreleaser in debug mode. makes it easier to debug a failure if there ever is one.
- cleans up build flag pathing in makefile.