### PR TITLE
update SDK version, rename and update compose file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 PLUGIN_NAME    := emulator
-PLUGIN_VERSION := 3.0.0-alpha.9
+PLUGIN_VERSION := 3.0.0-alpha.10
 IMAGE_NAME     := vaporio/emulator-plugin
 BIN_NAME       := synse-emulator-plugin
 
@@ -36,7 +36,7 @@ clean:  ## Remove temporary files
 
 .PHONY: deploy
 deploy:  ## Run a local deployment of the plugin with Synse Server
-	docker-compose -f compose.yml up -d
+	docker-compose up -d
 
 .PHONY: docker
 docker:  ## Build the docker image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,5 +26,8 @@ services:
     container_name: emulator
     image: vaporio/emulator-plugin
     command: ["--debug"]
+    environment:
+      PLUGIN_METRICS_ENABLED: "true"
     ports:
     - 5001:5001
+    - 2112:2112

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/vapor-ware/synse-emulator-plugin
 
 go 1.12
 
-require github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20190920193658-d0c0233f62cb
+require github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20191021183319-b68834744f25

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20190829162232-b73e0a002cef h1:4rl4+bpWMna7I8N4xsCvJahdccXMMAM5hUGeKOgEk3w=
-github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20190829162232-b73e0a002cef/go.mod h1:rc5tdj13+cxAtpERfwD0pP1/grXgWBg15lYEpVpi5hU=
-github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20190920193658-d0c0233f62cb h1:uBapiI4b6HNVdU7FxM67ZXQyZwkSqGsoDNCc/lG6gv4=
-github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20190920193658-d0c0233f62cb/go.mod h1:rc5tdj13+cxAtpERfwD0pP1/grXgWBg15lYEpVpi5hU=
+github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20191021183319-b68834744f25 h1:wbl3Kw4Lk6cZOvV8BIPRpYOKLBDQevVxwMVaxrmRjAQ=
+github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20191021183319-b68834744f25/go.mod h1:rc5tdj13+cxAtpERfwD0pP1/grXgWBg15lYEpVpi5hU=
 github.com/vapor-ware/synse-server-grpc v0.0.0-20190807170650-5374de18b9b4 h1:1ksn9Jm2+3xi8lQcm+a1/abs3wG2iGV7mTHRejCzqmY=
 github.com/vapor-ware/synse-server-grpc v0.0.0-20190807170650-5374de18b9b4/go.mod h1:66oRQ1KV/ZevAiiXbSUjRbx/h91xG/ArE/V39Jh872I=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION
This PR:
- bumps the emulator version to `3.0.0-alpha.10`
- updates dependencies to use the latest SDK which includes some bugfixes
- updates compose file name
- updates compose file to enable metrics and expose the metrics port