### PR TITLE
port emulated carousel for v3 emulator

### DIFF
--- a/config/device/carousel.yaml
+++ b/config/device/carousel.yaml
@@ -1,0 +1,11 @@
+version: 3
+devices:
+  - type: carousel
+    metadata:
+      model: emul8-carousel
+    instances:
+      - info: Synse Carousel
+        alias:
+          name: emulator-carousel
+        data:
+          id: 1

--- a/pkg/actions.go
+++ b/pkg/actions.go
@@ -17,6 +17,22 @@ var ActionAirflowValueEmitterSetup = sdk.DeviceAction{
 	},
 }
 
+// ActionCarouselValueEmitterSetup initializes a ValueEmitter for each "carousel" type device.
+var ActionCarouselValueEmitterSetup = sdk.DeviceAction{
+	Name: "Carousel value emitter setup",
+	Filter: map[string][]string{
+		"type": {"carousel"},
+	},
+	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
+		emitter := utils.NewValueEmitter(utils.Store).WithSeed(map[string]interface{}{
+			"state":    "ready",
+			"status":   "stopped",
+			"position": 1,
+		})
+		return utils.SetEmitter(d.GetID(), emitter)
+	},
+}
+
 // ActionEnergyValueEmitterSetup initializes a ValueEmitter for each "energy" type device.
 var ActionEnergyValueEmitterSetup = sdk.DeviceAction{
 	Name: "energy value emitter setup",

--- a/pkg/devices/carousel.go
+++ b/pkg/devices/carousel.go
@@ -1,0 +1,78 @@
+package devices
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/vapor-ware/synse-emulator-plugin/pkg/outputs"
+	"github.com/vapor-ware/synse-emulator-plugin/pkg/utils"
+	"github.com/vapor-ware/synse-sdk/sdk"
+	"github.com/vapor-ware/synse-sdk/sdk/output"
+)
+
+const (
+	statusStopped  = "stopped"
+	statusRotating = "rotating"
+
+	stateReady       = "ready"
+	stateUnavailable = "unavailable"
+)
+
+// Carousel is the handler for emulator carousel device(s).
+var Carousel = sdk.DeviceHandler{
+	Name:  "carousel",
+	Read:  carouselRead,
+	Write: carouselWrite,
+}
+
+// carouselRead is the read handler for emulated carousel device(s). It
+// returns the state, status, and position values for the device.
+func carouselRead(device *sdk.Device) ([]*output.Reading, error) {
+	emitter := utils.GetEmitter(device.GetID())
+
+	val := emitter.Next().(map[string]interface{})
+	return []*output.Reading{
+		output.State.MakeReading(val["state"]),
+		output.Status.MakeReading(val["status"]),
+		outputs.Position.MakeReading(val["position"]),
+	}, nil
+}
+
+// carouselWrite is the write handler for emulated carousel device(s). It
+// sets the position value for the device.
+func carouselWrite(device *sdk.Device, data *sdk.WriteData) error {
+	if len(data.Data) == 0 {
+		return fmt.Errorf("no values specified for 'data', but required")
+	}
+
+	emitter := utils.GetEmitter(device.GetID())
+	current := emitter.Next().(map[string]interface{})
+
+	switch data.Action {
+	case "position":
+		pos, err := strconv.Atoi(string(data.Data))
+		if err != nil {
+			return err
+		}
+
+		// Set the state to designate that the carousel is rotating.
+		current["state"] = stateUnavailable
+		current["status"] = statusRotating
+
+		// After a short while, update the state so the carousel is done
+		// rotating and in the new position.
+		go func() {
+			time.Sleep(5 * time.Second)
+
+			current["state"] = stateReady
+			current["status"] = statusStopped
+			current["position"] = pos
+			emitter.Set(current)
+		}()
+
+	default:
+		return fmt.Errorf("unsupported write action: %v", data.Action)
+	}
+	return nil
+}

--- a/pkg/outputs/outputs.go
+++ b/pkg/outputs/outputs.go
@@ -12,4 +12,9 @@ var (
 			Symbol: "mm/s",
 		},
 	}
+
+	// Position is an output which describes positional state.
+	Position = output.Output{
+		Name: "position",
+	}
 )

--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -26,6 +26,7 @@ func MakePlugin() *sdk.Plugin {
 	// Register device handlers
 	err = plugin.RegisterDeviceHandlers(
 		&devices.Airflow,
+		&devices.Carousel,
 		&devices.Energy,
 		&devices.Fan,
 		&devices.Humidity,
@@ -44,6 +45,7 @@ func MakePlugin() *sdk.Plugin {
 	// devices' value emitters for each device.
 	err = plugin.RegisterDeviceSetupActions(
 		&ActionAirflowValueEmitterSetup,
+		&ActionCarouselValueEmitterSetup,
 		&ActionEnergyValueEmitterSetup,
 		&ActionFanValueEmitterSetup,
 		&ActionHumidityValueEmitterSetup,


### PR DESCRIPTION
This PR:
- adds the carousel device to the synse v3 branch. due to the changes from v2->v3, this could not just be merged/picked from master onto this branch.