### PR TITLE
add frequency and current devices

### DIFF
--- a/pkg/actions.go
+++ b/pkg/actions.go
@@ -33,6 +33,18 @@ var ActionCarouselValueEmitterSetup = sdk.DeviceAction{
 	},
 }
 
+// ActionCurrentValueEmitterSetup initializes a ValueEmitter for each "current" type device.
+var ActionCurrentValueEmitterSetup = sdk.DeviceAction{
+	Name: "current value emitter setup",
+	Filter: map[string][]string{
+		"type": {"current"},
+	},
+	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
+		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(0).WithUpperBound(30)
+		return utils.SetEmitter(d.GetID(), emitter)
+	},
+}
+
 // ActionEnergyValueEmitterSetup initializes a ValueEmitter for each "energy" type device.
 var ActionEnergyValueEmitterSetup = sdk.DeviceAction{
 	Name: "energy value emitter setup",
@@ -53,6 +65,18 @@ var ActionFanValueEmitterSetup = sdk.DeviceAction{
 	},
 	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
 		emitter := utils.NewValueEmitter(utils.Store).WithSeed(0)
+		return utils.SetEmitter(d.GetID(), emitter)
+	},
+}
+
+// ActionFrequencyValueEmitterSetup initializes a ValueEmitter for each "frequency" type device.
+var ActionFrequencyValueEmitterSetup = sdk.DeviceAction{
+	Name: "frequency value emitter setup",
+	Filter: map[string][]string{
+		"type": {"frequency"},
+	},
+	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
+		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(0).WithUpperBound(60)
 		return utils.SetEmitter(d.GetID(), emitter)
 	},
 }

--- a/pkg/devices/current.go
+++ b/pkg/devices/current.go
@@ -1,0 +1,22 @@
+package devices
+
+import (
+	"github.com/vapor-ware/synse-emulator-plugin/pkg/utils"
+	"github.com/vapor-ware/synse-sdk/sdk"
+	"github.com/vapor-ware/synse-sdk/sdk/output"
+)
+
+// Current is the handler for the emulated current device(s).
+var Current = sdk.DeviceHandler{
+	Name:  "current",
+	Read:  currentRead,
+	Write: minMaxCurrentWrite,
+}
+
+// currentRead is the read handler for the emulated current device(s).
+func currentRead(device *sdk.Device) ([]*output.Reading, error) {
+	emitter := utils.GetEmitter(device.GetID())
+	return []*output.Reading{
+		output.ElectricCurrent.MakeReading(emitter.Next()),
+	}, nil
+}

--- a/pkg/devices/frequency.go
+++ b/pkg/devices/frequency.go
@@ -1,0 +1,22 @@
+package devices
+
+import (
+	"github.com/vapor-ware/synse-emulator-plugin/pkg/utils"
+	"github.com/vapor-ware/synse-sdk/sdk"
+	"github.com/vapor-ware/synse-sdk/sdk/output"
+)
+
+// Frequency is the handler for the emulated frequency device(s).
+var Frequency = sdk.DeviceHandler{
+	Name:  "frequency",
+	Read:  frequencyRead,
+	Write: minMaxCurrentWrite,
+}
+
+// frequencyRead is the read handler for the emulated frequency device(s).
+func frequencyRead(device *sdk.Device) ([]*output.Reading, error) {
+	emitter := utils.GetEmitter(device.GetID())
+	return []*output.Reading{
+		output.Frequency.MakeReading(emitter.Next()),
+	}, nil
+}

--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -27,8 +27,10 @@ func MakePlugin() *sdk.Plugin {
 	err = plugin.RegisterDeviceHandlers(
 		&devices.Airflow,
 		&devices.Carousel,
+		&devices.Current,
 		&devices.Energy,
 		&devices.Fan,
+		&devices.Frequency,
 		&devices.Humidity,
 		&devices.LED,
 		&devices.Lock,
@@ -46,8 +48,10 @@ func MakePlugin() *sdk.Plugin {
 	err = plugin.RegisterDeviceSetupActions(
 		&ActionAirflowValueEmitterSetup,
 		&ActionCarouselValueEmitterSetup,
+		&ActionCurrentValueEmitterSetup,
 		&ActionEnergyValueEmitterSetup,
 		&ActionFanValueEmitterSetup,
+		&ActionFrequencyValueEmitterSetup,
 		&ActionHumidityValueEmitterSetup,
 		&ActionLEDValueEmitterSetup,
 		&ActionLockValueEmitterSetup,


### PR DESCRIPTION
This PR:
- adds "current" and "frequency" type devices to the emulator.

This was added to the master (synse v2) build in https://github.com/vapor-ware/synse-emulator-plugin/pull/57, but was not rolled up into the v3 work, until now. 