### PR TITLE
fix device misconfiguration: key change for v3 config

### DIFF
--- a/config/device/airflow.yaml
+++ b/config/device/airflow.yaml
@@ -1,7 +1,7 @@
 version: 3
 devices:
   - type: airflow
-    metadata:
+    context:
       model: emul8-air
     instances:
       - info: Synse Airflow Sensor

--- a/config/device/carousel.yaml
+++ b/config/device/carousel.yaml
@@ -1,7 +1,7 @@
 version: 3
 devices:
   - type: carousel
-    metadata:
+    context:
       model: emul8-carousel
     instances:
       - info: Synse Carousel

--- a/config/device/fan.yaml
+++ b/config/device/fan.yaml
@@ -1,7 +1,7 @@
 version: 3
 devices:
   - type: fan
-    metadata:
+    context:
       model: emul8-fan
     instances:
       - info: Synse Fan

--- a/config/device/humidity.yaml
+++ b/config/device/humidity.yaml
@@ -1,7 +1,7 @@
 version: 3
 devices:
   - type: humidity
-    metadata:
+    context:
       model: emul8-humidity
     instances:
       - info: Synse Humidity Sensor

--- a/config/device/led.yaml
+++ b/config/device/led.yaml
@@ -1,7 +1,7 @@
 version: 3
 devices:
   - type: led
-    metadata:
+    context:
       model: emul8-led
     instances:
       - info: Synse LED

--- a/config/device/lock.yaml
+++ b/config/device/lock.yaml
@@ -1,7 +1,7 @@
 version: 3
 devices:
   - type: lock
-    metadata:
+    context:
       model: emul8-lock
     instances:
       - info: Synse Door Lock

--- a/config/device/power.yaml
+++ b/config/device/power.yaml
@@ -1,7 +1,7 @@
 version: 3
 devices:
   - type: power
-    metadata:
+    context:
       model: emul8-power
     instances:
       - info: Zone 1 Power
@@ -21,7 +21,7 @@ devices:
           id: 5
 
   - type: voltage
-    metadata:
+    context:
       model: emul8-voltage
     instances:
       - info: Zone 1 Voltage
@@ -32,7 +32,7 @@ devices:
           id: 2
 
   - type: energy
-    metadata:
+    context:
       model: emul8-energy
     instances:
       - info: Zone 1 Kilowatt-hour

--- a/config/device/pressure.yaml
+++ b/config/device/pressure.yaml
@@ -1,7 +1,7 @@
 version: 3
 devices:
   - type: pressure
-    metadata:
+    context:
       model: emul8-pressure
     instances:
       - info: Synse Pressure Sensor 1

--- a/config/device/temperature.yaml
+++ b/config/device/temperature.yaml
@@ -1,7 +1,7 @@
 version: 3
 devices:
   - type: temperature
-    metadata:
+    context:
       model: emul8-temp
     instances:
       - info: Synse Temperature Sensor 1


### PR DESCRIPTION
This PR:
- fixes misconfiguration in device configs for v3, where the "metadata" key was replaced by "context"