### PR TITLE
add missing type field to custom emulator outputs

### DIFF
--- a/pkg/outputs/outputs.go
+++ b/pkg/outputs/outputs.go
@@ -6,6 +6,7 @@ var (
 	// Airflow is the output type for airflow readings.
 	Airflow = output.Output{
 		Name:      "airflow",
+		Type:      "speed",
 		Precision: 3,
 		Unit: &output.Unit{
 			Name:   "millimeters per second",
@@ -16,5 +17,6 @@ var (
 	// Position is an output which describes positional state.
 	Position = output.Output{
 		Name: "position",
+		Type: "position",
 	}
 )


### PR DESCRIPTION
This PR:
- adds in a missing `Type` definition for custom emulator outputs. In v2, type/name were sorta the same; in v3 they are called out explicitly. The output types here were not updated completely to reflect that.