### PR TITLE
feat: add dockerfile for building dev/debug images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,3 +24,4 @@ vendor/
 **/*.md
 **/*.rst
 NOTICE
+!README.md

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,27 @@
+#
+# Development Dockerfile
+#
+# This Dockerfile produces an image intended to only be used for
+# development and debugging. It should NOT be used in production.
+# Development images contain additional tooling that makes it easier
+# to exec into a contain and dig into whatever may be going on inside.
+#
+
+FROM vaporio/golang:1.13
+
+WORKDIR /synse
+
+# Build the device configurations directly into the image. This is not
+# generally advised, but is acceptable here since the plugin is merely
+# an emulator and its config is not tied to anything real. These config
+# defaults may be overridden at run time.
+COPY config/device  /etc/synse/plugin/config/device
+COPY config.yml     /etc/synse/plugin/config/config.yml
+
+# Copy the executable and README information. The executable should be
+# built prior to the image build (see Makefile).
+COPY synse-emulator-plugin ./plugin
+COPY README.md .
+
+EXPOSE 5001
+ENTRYPOINT ["./plugin"]

--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,16 @@ deploy:  ## Run a local deployment of the plugin with Synse Server
 	docker-compose up -d
 
 .PHONY: docker
-docker:  ## Build the docker image
+docker:  ## Build the production docker image locally
 	docker build -f Dockerfile \
 		--label "org.label-schema.build-date=${BUILD_DATE}" \
 		--label "org.label-schema.vcs-ref=${GIT_COMMIT}" \
 		--label "org.label-schema.version=${PLUGIN_VERSION}" \
 		-t ${IMAGE_NAME}:latest .
+
+.PHONY: docker-dev
+docker-dev:  ## Build the development docker image locally
+	docker build -f Dockerfile.dev -t ${IMAGE_NAME}:dev-${GIT_COMMIT} .
 
 .PHONY: fmt
 fmt:  ## Run goimports on all go files

--- a/README.md
+++ b/README.md
@@ -136,19 +136,39 @@ Handlers set up this way will have the `min`, `max`, and `current` write actions
 
 ### Debugging
 
-The plugin can be run in debug mode for additional logging. This is done by setting
+The plugin can be run in debug mode for additional logging. This is done by:
 
-```yaml
-debug: true
+- Setting the `debug` option  to `true` in the plugin configuration YAML ([config.yml](config.yml))
+
+  ```yaml
+  debug: true
+  ```
+
+- Passing the `--debug` flag when running the binary/image
+
+  ```
+  docker run vaporio/emulator-plugin --debug
+  ```
+
+- Running the image with the `PLUGIN_DEBUG` environment variable set to `true`
+
+  ```
+  docker run -e PLUGIN_DEBUG=true vaporio/emulator-plugin
+  ```
+
+A [development/debug Dockerfile](Dockerfile.dev) is provided in the project repository to enable
+building image which may be useful when developing or debugging a plugin. Unlike the slim `scratch`-based
+production image, the development image uses an ubuntu base, bringing with it all the standard command line
+tools one would expect. To build a development image:
+
+```
+make docker-dev
 ```
 
-in the plugin configuration YAML ([config.yml](config.yml))
+The built image will be tagged using the format `dev-{COMMIT}`, where `COMMIT` is the short commit for
+the repository at the time. This image is not published as part of the CI pipeline, but those with access
+to the Docker Hub repo may publish manually.
 
-The plugin may also be run with the `--debug` flag, e.g.
-
-```
-docker run vaporio/emulator-plugin --debug
-```
 
 ### Bugs / Issues
 

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20191105134802-f8ee5dba84f4 h1:6sdLKAOAlvfJiIed+C+SVRaJZF74EenNOZxFGzDvIbo=
-github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20191105134802-f8ee5dba84f4/go.mod h1:rc5tdj13+cxAtpERfwD0pP1/grXgWBg15lYEpVpi5hU=
 github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200116192645-2f6842d278ad h1:LLwxCKM51Fu98PQpGpVquotx9NnVkI+qMebiW/vs52k=
 github.com/vapor-ware/synse-sdk v0.1.0-alpha.0.20200116192645-2f6842d278ad/go.mod h1:rc5tdj13+cxAtpERfwD0pP1/grXgWBg15lYEpVpi5hU=
 github.com/vapor-ware/synse-server-grpc v0.0.0-20190807170650-5374de18b9b4 h1:1ksn9Jm2+3xi8lQcm+a1/abs3wG2iGV7mTHRejCzqmY=


### PR DESCRIPTION
This PR:
-  Adds a Dockerfile for building  development/debug images locally.
-  Updates the README with details about this image


Note that this image is not published via CI. It could be, but it seems unnecessary to  do that for every commit.

In a way, this PR is a proposal of what this image / process could look like, so feedback appreciated. Once this looks solid, I can work my way through other plugins and add the same to make building these kinds of images easier.