### PR TITLE
ci: filter changelong on standardized set of commit message prefixes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,3 +55,7 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+    - '^wip:'
+    - '^deps:'
+    - '^bump:'
+    - '^typo:'


### PR DESCRIPTION
This PR:
-  adds a number of commit prefixes to the list of those ignored when building a release changelog


Any suggestions for additional prefixes  are welcome (: