### PR TITLE
bugfix: fix improper use of case statement in LED write hander for state

### DIFF
--- a/pkg/devices/led.go
+++ b/pkg/devices/led.go
@@ -56,9 +56,7 @@ func ledWrite(device *sdk.Device, data *sdk.WriteData) error {
 
 	case "state":
 		switch cmd := string(data.Data); cmd {
-		case stateOn:
-		case stateOff:
-		case stateBlink:
+		case stateOn, stateOff, stateBlink:
 			current["state"] = cmd
 			emitter.Set(current)
 		default:


### PR DESCRIPTION
This PR:
- Fixes a bug in the LED device handler write function where the case statement for handling state writes was declared improperly.

fixes #93 