### PR TITLE
bugfix: panic with error message when emulator device is improperly configured

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/vapor-ware/synse-emulator-plugin
 go 1.13
 
 require (
+	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/creasty/defaults v1.5.1 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/mitchellh/mapstructure v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=

--- a/pkg/utils/state.go
+++ b/pkg/utils/state.go
@@ -1,13 +1,27 @@
 package utils
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+)
 
 // deviceEmitters maps the ID of each device to their ValueEmitter.
 var deviceEmitters = map[string]*ValueEmitter{}
 
 // GetEmitter gets the ValueEmitter for the specified device.
 func GetEmitter(id string) *ValueEmitter {
-	return deviceEmitters[id]
+	if emitter := deviceEmitters[id]; emitter == nil {
+		panic(heredoc.Doc(fmt.Sprintf(`
+			No value emitter is configured for device %s.
+
+			Ensure that the plugin device configuration is correct and device types
+			match those specified in the filters for plugin setup actions.
+			(synse-emulator-plugin/pkg/actions.go)`, id,
+		)))
+	} else {
+		return emitter
+	}
 }
 
 // SetEmitter adds a ValueEmitter for the specified device.


### PR DESCRIPTION
This PR:
- explicitly panics if a device tries to get a values emitter, but has none set up for it. this is considered a device configuration error for the plugin, where the device type is either incorrectly specified, or not yet supported.

I was initially thinking of having some default emitter be used in this case, but that feels wrong since that would cover up the fact that something is misconfigured. Now, instead of panicing with just a nil pointer dereference, we have an error message which should provide enough context/info for the issue to be easily identified and resolved.

fixes #103 


The error message ends up looking like this:

```
time="2020-12-08T04:50:00.404Z" level=info msg="[scheduler] starting write scheduling" delay=0s interval=2s mode=parallel
panic: No value emitter is configured for device 9cdf5ffa-7a04-5345-9214-6742a7b678e8. 

Ensure that the plugin device configuration is correct and device types 
match those specified in the filters for plugin setup actions.
(synse-emulator-plugin/pkg/actions.go)

goroutine 112 [running]:
github.com/vapor-ware/synse-emulator-plugin/pkg/utils.GetEmitter(0xc0004ae480, 0x24, 0x68)
	/Users/edaniszewski/dev/vaporio/synse-emulator-plugin/pkg/utils/state.go:14 +0x125
github.com/vapor-ware/synse-emulator-plugin/pkg/devices.temperatureRead(0xc000493d40, 0xa02510a7c35609d0, 0x203000, 0x0, 0xc000516ad0, 0x203000)
	/Users/edaniszewski/dev/vaporio/synse-emulator-plugin/pkg/devices/temperature.go:18 +0x45
github.com/vapor-ware/synse-sdk/sdk.(*Device).Read(0xc000493d40, 0xc000516d38, 0xc0005360e0, 0x6)
	/Users/edaniszewski/go/pkg/mod/github.com/vapor-ware/synse-sdk@v0.1.0-alpha.0.20201202203005-962b9433e02a/sdk/device.go:412 +0x73
github.com/vapor-ware/synse-sdk/sdk.(*scheduler).read(0xc000388f80, 0xc000493d40)
	/Users/edaniszewski/go/pkg/mod/github.com/vapor-ware/synse-sdk@v0.1.0-alpha.0.20201202203005-962b9433e02a/sdk/scheduler.go:560 +0x336
github.com/vapor-ware/synse-sdk/sdk.(*scheduler).scheduleReads.func1(0xc000388f80, 0xc0004f1880, 0xc000493d40)
	/Users/edaniszewski/go/pkg/mod/github.com/vapor-ware/synse-sdk@v0.1.0-alpha.0.20201202203005-962b9433e02a/sdk/scheduler.go:333 +0x35
created by github.com/vapor-ware/synse-sdk/sdk.(*scheduler).scheduleReads
	/Users/edaniszewski/go/pkg/mod/github.com/vapor-ware/synse-sdk@v0.1.0-alpha.0.20201202203005-962b9433e02a/sdk/scheduler.go:332 +0x33e
```