### PR TITLE
feat: allow walk ranges and step to be configurable via YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,66 @@ Handlers set up this way will have the `min`, `max`, and `current` write actions
 |             | `max`         | `int`      | The maximum bound for readings to be generated within. |
 |             | `current`     | `int`      | The static current reading value. |
 
+### Device Configurations
+
+In addition to allowing values to be set via writing to devices, the behaviors/data ranges
+for device readings may also be configured in the device configuration YAML for certain
+devices. These options should be set under a device's `data` configuration, e.g.
+
+```yaml
+version: 3
+devices:
+  - type: temperature
+    context:
+      model: emul8-temp
+    instances:
+      - info: Synse Temperature Sensor 1
+        data:
+          id: 1
+          min: 20
+          max: 40
+```
+
+The table below describes the supported configuration values for each type. None of the values
+are required to be set and falls back on sane defaults. Definitions for the settings follow:
+
+* `min`: The lower bound for a random walk. The walk will not subceed this value.
+* `max`: The upper bound for a random walk. The walk will not exceed this value.
+* `step`: The maximum size that a random walk may step by. For each iteration, the step is randomly chosen
+   between this max step size and 0.
+* `seed`: The starting value for the device.
+
+
+| Device Type | Setting | Type  | Default |
+| :---------: | :-----: | :---: | :-----: |
+| airflow     | `min`   | int   | -100 |
+|             | `max`   | int   | 100 |
+|             | `step`  | int   | 4 |
+| current     | `min`   | int   | 0 |
+|             | `max`   | int   | 30 |
+|             | `step`  | int   | 4 |
+| energy      | `min`   | int   | 0 |
+|             | `max`   | int   | 100000 |
+| fan         | `seed`  | int   | 0 |
+| frequency   | `min`   | int   | 0 |
+|             | `max`   | int   | 60 |
+|             | `step`  | int   | 4 |
+| humidity    | `min`   | int   | 0 |
+|             | `max`   | int   | 100 |
+|             | `step`  | int   | 4 |
+| power       | `min`   | int   | 1000 |
+|             | `max`   | int   | 3000 |
+|             | `step`  | int   | 4 |
+| pressure    | `min`   | int   | -5 |
+|             | `max`   | int   | 5 |
+|             | `step`  | int   | 4 |
+| temperature | `min`   | int   | 0 |
+|             | `max`   | int   | 100 |
+|             | `step`  | int   | 4 |
+| voltage     | `min`   | int   | 100 |
+|             | `max`   | int   | 500 |
+|             | `step`  | int   | 0 |
+
 ## Compatibility
 
 Below is a table describing the compatibility of plugin versions with Synse platform versions.
@@ -141,7 +201,6 @@ Below is a table describing the compatibility of plugin versions with Synse plat
 | plugin v1.x | ✗        | ✗        |
 | plugin v2.x | ✓        | ✗        |
 | plugin v3.x | ✗        | ✓        |
-
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -153,14 +153,14 @@ devices:
 ```
 
 The table below describes the supported configuration values for each type. None of the values
-are required to be set and falls back on sane defaults. Definitions for the settings follow:
+specified below are required to be set. If omitted, the plugin falls back on sane defaults.
+Definitions for the settings follow:
 
 * `min`: The lower bound for a random walk. The walk will not subceed this value.
 * `max`: The upper bound for a random walk. The walk will not exceed this value.
 * `step`: The maximum size that a random walk may step by. For each iteration, the step is randomly chosen
    between this max step size and 0.
 * `seed`: The starting value for the device.
-
 
 | Device Type | Setting | Type  | Default |
 | :---------: | :-----: | :---: | :-----: |

--- a/pkg/actions.go
+++ b/pkg/actions.go
@@ -12,7 +12,22 @@ var ActionAirflowValueEmitterSetup = sdk.DeviceAction{
 		"type": {"airflow"},
 	},
 	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
-		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(-100).WithUpperBound(100)
+		lowerBound, ok := d.Data["min"].(int)
+		if !ok {
+			lowerBound = -100
+		}
+
+		upperBound, ok := d.Data["max"].(int)
+		if !ok {
+			upperBound = 100
+		}
+
+		step, ok := d.Data["step"].(int)
+		if !ok {
+			step = 0
+		}
+
+		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(lowerBound).WithUpperBound(upperBound).WithStep(step)
 		return utils.SetEmitter(d.GetID(), emitter)
 	},
 }
@@ -74,7 +89,22 @@ var ActionCurrentValueEmitterSetup = sdk.DeviceAction{
 		"type": {"current"},
 	},
 	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
-		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(0).WithUpperBound(30)
+		lowerBound, ok := d.Data["min"].(int)
+		if !ok {
+			lowerBound = 0
+		}
+
+		upperBound, ok := d.Data["max"].(int)
+		if !ok {
+			upperBound = 30
+		}
+
+		step, ok := d.Data["step"].(int)
+		if !ok {
+			step = 0
+		}
+
+		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(lowerBound).WithUpperBound(upperBound).WithStep(step)
 		return utils.SetEmitter(d.GetID(), emitter)
 	},
 }
@@ -86,7 +116,17 @@ var ActionEnergyValueEmitterSetup = sdk.DeviceAction{
 		"type": {"energy"},
 	},
 	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
-		emitter := utils.NewValueEmitter(utils.Accumulate).WithLowerBound(0).WithUpperBound(100000)
+		lowerBound, ok := d.Data["min"].(int)
+		if !ok {
+			lowerBound = 0
+		}
+
+		upperBound, ok := d.Data["max"].(int)
+		if !ok {
+			upperBound = 100000
+		}
+
+		emitter := utils.NewValueEmitter(utils.Accumulate).WithLowerBound(lowerBound).WithUpperBound(upperBound)
 		return utils.SetEmitter(d.GetID(), emitter)
 	},
 }
@@ -99,7 +139,12 @@ var ActionFanValueEmitterSetup = sdk.DeviceAction{
 	},
 	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
 		if d.GetHandler().Name == "fan" {
-			emitter := utils.NewValueEmitter(utils.Store).WithSeed(0)
+			seed, ok := d.Data["seed"].(int)
+			if !ok {
+				seed = 0
+			}
+
+			emitter := utils.NewValueEmitter(utils.Store).WithSeed(seed)
 			return utils.SetEmitter(d.GetID(), emitter)
 		}
 		return nil
@@ -114,7 +159,12 @@ var ActionFanMultiValueEmitterSetup = sdk.DeviceAction{
 	},
 	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
 		if d.GetHandler().Name == "fan-multi" {
-			emitter := utils.NewValueEmitter(utils.Store).WithSeed(0)
+			seed, ok := d.Data["seed"].(int)
+			if !ok {
+				seed = 0
+			}
+
+			emitter := utils.NewValueEmitter(utils.Store).WithSeed(seed)
 			return utils.SetEmitter(d.GetID(), emitter)
 		}
 		return nil
@@ -128,7 +178,22 @@ var ActionFrequencyValueEmitterSetup = sdk.DeviceAction{
 		"type": {"frequency"},
 	},
 	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
-		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(0).WithUpperBound(60)
+		lowerBound, ok := d.Data["min"].(int)
+		if !ok {
+			lowerBound = 0
+		}
+
+		upperBound, ok := d.Data["max"].(int)
+		if !ok {
+			upperBound = 60
+		}
+
+		step, ok := d.Data["step"].(int)
+		if !ok {
+			step = 0
+		}
+
+		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(lowerBound).WithUpperBound(upperBound).WithStep(step)
 		return utils.SetEmitter(d.GetID(), emitter)
 	},
 }
@@ -140,7 +205,22 @@ var ActionHumidityValueEmitterSetup = sdk.DeviceAction{
 		"type": {"humidity"},
 	},
 	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
-		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(0).WithUpperBound(100)
+		lowerBound, ok := d.Data["min"].(int)
+		if !ok {
+			lowerBound = 0
+		}
+
+		upperBound, ok := d.Data["max"].(int)
+		if !ok {
+			upperBound = 100
+		}
+
+		step, ok := d.Data["step"].(int)
+		if !ok {
+			step = 0
+		}
+
+		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(lowerBound).WithUpperBound(upperBound).WithStep(step)
 		return utils.SetEmitter(d.GetID(), emitter)
 	},
 }
@@ -179,7 +259,22 @@ var ActionPowerValueEmitterSetup = sdk.DeviceAction{
 		"type": {"power"},
 	},
 	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
-		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(1000).WithUpperBound(3000)
+		lowerBound, ok := d.Data["min"].(int)
+		if !ok {
+			lowerBound = 1000
+		}
+
+		upperBound, ok := d.Data["max"].(int)
+		if !ok {
+			upperBound = 3000
+		}
+
+		step, ok := d.Data["step"].(int)
+		if !ok {
+			step = 0
+		}
+
+		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(lowerBound).WithUpperBound(upperBound).WithStep(step)
 		return utils.SetEmitter(d.GetID(), emitter)
 	},
 }
@@ -191,7 +286,22 @@ var ActionPressureValueEmitterSetup = sdk.DeviceAction{
 		"type": {"pressure"},
 	},
 	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
-		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(-5).WithUpperBound(5)
+		lowerBound, ok := d.Data["min"].(int)
+		if !ok {
+			lowerBound = -5
+		}
+
+		upperBound, ok := d.Data["max"].(int)
+		if !ok {
+			upperBound = 5
+		}
+
+		step, ok := d.Data["step"].(int)
+		if !ok {
+			step = 0
+		}
+
+		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(lowerBound).WithUpperBound(upperBound).WithStep(step)
 		return utils.SetEmitter(d.GetID(), emitter)
 	},
 }
@@ -203,7 +313,22 @@ var ActionTemperatureValueEmitterSetup = sdk.DeviceAction{
 		"type": {"temperature"},
 	},
 	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
-		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(0).WithUpperBound(100)
+		lowerBound, ok := d.Data["min"].(int)
+		if !ok {
+			lowerBound = 0
+		}
+
+		upperBound, ok := d.Data["max"].(int)
+		if !ok {
+			upperBound = 100
+		}
+
+		step, ok := d.Data["step"].(int)
+		if !ok {
+			step = 0
+		}
+
+		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(lowerBound).WithUpperBound(upperBound).WithStep(step)
 		return utils.SetEmitter(d.GetID(), emitter)
 	},
 }
@@ -215,7 +340,22 @@ var ActionVoltageValueEmitterSetup = sdk.DeviceAction{
 		"type": {"voltage"},
 	},
 	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
-		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(100).WithUpperBound(500)
+		lowerBound, ok := d.Data["min"].(int)
+		if !ok {
+			lowerBound = 100
+		}
+
+		upperBound, ok := d.Data["max"].(int)
+		if !ok {
+			upperBound = 500
+		}
+
+		step, ok := d.Data["step"].(int)
+		if !ok {
+			step = 0
+		}
+
+		emitter := utils.NewValueEmitter(utils.RandomWalk).WithLowerBound(lowerBound).WithUpperBound(upperBound).WithStep(step)
 		return utils.SetEmitter(d.GetID(), emitter)
 	},
 }

--- a/pkg/utils/emitter.go
+++ b/pkg/utils/emitter.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"math"
 	"math/rand"
 	"sync"
 	"time"
@@ -36,6 +37,7 @@ type ValueEmitter struct {
 	prev       interface{}
 	upperBound int
 	lowerBound int
+	step       int
 }
 
 // NewValueEmitter creates a new ValueEmitter for the specified mode.
@@ -85,7 +87,7 @@ func (emitter *ValueEmitter) Next() interface{} {
 		emitter.prev = BoundedIncrement(emitter.prev, emitter.lowerBound, emitter.upperBound)
 
 	case RandomWalk:
-		emitter.prev = RandWalkInRange(emitter.prev, emitter.lowerBound, emitter.upperBound)
+		emitter.prev = RandWalkInRange(emitter.prev, emitter.lowerBound, emitter.upperBound, emitter.step)
 
 	case Store:
 	}
@@ -139,5 +141,12 @@ func (emitter *ValueEmitter) WithUpperBound(bound int) *ValueEmitter {
 //   	bound, it will start forcing the walk upwards.
 func (emitter *ValueEmitter) WithLowerBound(bound int) *ValueEmitter {
 	emitter.lowerBound = bound
+	return emitter
+}
+
+// WithStep allows the device to set the maximum step range for an emitter
+// implementation which performs a stepped walk.
+func (emitter *ValueEmitter) WithStep(step int) *ValueEmitter {
+	emitter.step = int(math.Abs(float64(step)))
 	return emitter
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -25,6 +25,11 @@ func BoundedIncrement(start interface{}, lower, upper int) int {
 
 // RandWalkInRange creates a new value by walking a random distance from the
 // start value.
+//
+// The upper and lower bounds for the walk must be specified. All generated data
+// is guaranteed to fall within those bounds. The step size is a random value between
+// 0 and the specified max step; if the provided step size is 0, this defaults to a
+// maximum step size of 4.
 func RandWalkInRange(start interface{}, lower, upper, step int) int {
 	// Between readings, we allow the value to change between 0 and 4.
 	// This allows for some movement, but doesn't allow massive swings in

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -25,11 +25,15 @@ func BoundedIncrement(start interface{}, lower, upper int) int {
 
 // RandWalkInRange creates a new value by walking a random distance from the
 // start value.
-func RandWalkInRange(start interface{}, lower, upper int) int {
+func RandWalkInRange(start interface{}, lower, upper, step int) int {
 	// Between readings, we allow the value to change between 0 and 4.
 	// This allows for some movement, but doesn't allow massive swings in
 	// short periods.
-	diff := RandIntInRange(0, 4)
+	maxStep := 4
+	if step != 0 {
+		maxStep = step
+	}
+	diff := RandIntInRange(0, maxStep)
 
 	// If a seed is not set, start at the midway point between the lower and upper bounds.
 	if start == nil {


### PR DESCRIPTION
This PR:
-  allows devices of particular types (based on the type of data emitter they  use internally) to  expose  data seed/bound/step  configurations in the device YAML.
- adds documentation in README


Once approved and merged, the version  will be updated and a new release cut.

[VIO-1300]

[VIO-1300]: https://vaporio.atlassian.net/browse/VIO-1300