### PR TITLE
fix: add percentage reading to humidity device return

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,33 @@
 #
-# compose.yml
+# docker-compose.yml
 #
 # A simple compose file to run a dockerized emulator plugin
 # instance with Synse Server, both in debug mode.
 #
 # To run:
-#    docker-compose -f compose.yml up -d
+#    docker-compose up -d
 #
 
-version: '3'
+version: "3"
 services:
   synse-server:
     container_name: synse-server
     image: vaporio/synse-server
     ports:
-    - '5000:5000'
+      - "5000:5000"
     links:
-    - emulator
+      - emulator
     environment:
       SYNSE_LOGGING: debug
       SYNSE_PLUGIN_TCP: emulator:5001
-      SYNSE_METRICS_ENABLED: 'true'
+      SYNSE_METRICS_ENABLED: "true"
 
   emulator:
     container_name: emulator
     image: vaporio/emulator-plugin
-    command: ['--debug']
+    command: ["--debug"]
     ports:
-    - '5001:5001'
-    - '2112:2112'
+      - "5001:5001"
+      - "2112:2112"
     environment:
-      PLUGIN_METRICS_ENABLED: 'true'
+      PLUGIN_METRICS_ENABLED: "true"

--- a/pkg/devices/humidity.go
+++ b/pkg/devices/humidity.go
@@ -16,8 +16,10 @@ var Humidity = sdk.DeviceHandler{
 // humidityRead is the read handler for the emulated humidity device(s).
 func humidityRead(device *sdk.Device) ([]*output.Reading, error) {
 	emitter := utils.GetEmitter(device.GetID())
+	humidity := emitter.Next()
 	return []*output.Reading{
-		output.Humidity.MakeReading(emitter.Next()),
+		output.Humidity.MakeReading(humidity),
+		output.Percentage.MakeReading(humidity), // https://vaporio.atlassian.net/browse/VIO-1389
 		output.Temperature.MakeReading(emitter.Next()),
 	}, nil
 }


### PR DESCRIPTION
This PR:
- adds a "percentage" type reading to humdity-type devices
- fixes comment + formats docker-compose file

```console
$ curl localhost:5000/v3/read/fef34490-4952-5e92-bf4d-aad169df980e
[
  {
    "device": "fef34490-4952-5e92-bf4d-aad169df980e",
    "timestamp": "2021-09-14T18:20:10Z",
    "type": "humidity",
    "device_type": "humidity",
    "device_info": "",
    "unit": {
      "name": "percent humidity",
      "symbol": "%"
    },
    "value": 57,
    "context": {
      "model": "emul8-humidity"
    }
  },
  {
    "device": "fef34490-4952-5e92-bf4d-aad169df980e",
    "timestamp": "2021-09-14T18:20:10Z",
    "type": "percentage",
    "device_type": "humidity",
    "device_info": "",
    "unit": {
      "name": "percent",
      "symbol": "%"
    },
    "value": 57,
    "context": {
      "model": "emul8-humidity"
    }
  },
  {
    "device": "fef34490-4952-5e92-bf4d-aad169df980e",
    "timestamp": "2021-09-14T18:20:10Z",
    "type": "temperature",
    "device_type": "humidity",
    "device_info": "",
    "unit": {
      "name": "celsius",
      "symbol": "C"
    },
    "value": 58,
    "context": {
      "model": "emul8-humidity"
    }
  }
]
```


fixes [VIO-1389]

[VIO-1389]: https://vaporio.atlassian.net/browse/VIO-1389