### PR TITLE
[VIO-2709] UPS emulation

### DIFF
--- a/config/device/ups.yaml
+++ b/config/device/ups.yaml
@@ -1,6 +1,6 @@
 version: 3
 devices:
-  - type: duration
+  - type: seconds
     context:
       model: emul8-ups
     instances:

--- a/config/device/ups.yaml
+++ b/config/device/ups.yaml
@@ -1,0 +1,9 @@
+version: 3
+devices:
+  - type: duration
+    context:
+      model: emul8-ups
+    instances:
+      - info: Seconds on battery power
+        data:
+          id: 1

--- a/pkg/actions.go
+++ b/pkg/actions.go
@@ -256,7 +256,7 @@ var ActionLockValueEmitterSetup = sdk.DeviceAction{
 var ActionUpsDurationValueEmitterSetup = sdk.DeviceAction{
 	Name: "UPS Duration emitter setup",
 	Filter: map[string][]string{
-		"type": {"duration"},
+		"type": {"seconds"},
 	},
 	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
 		lowerBound, ok := d.Data["min"].(int)

--- a/pkg/actions.go
+++ b/pkg/actions.go
@@ -252,7 +252,7 @@ var ActionLockValueEmitterSetup = sdk.DeviceAction{
 	},
 }
 
-// ActionUpsDurationValueEmitterSetup initializes a ValueEmitter for each "duration" type device
+// ActionUpsDurationValueEmitterSetup initializes a ValueEmitter for each "seconds" type device
 var ActionUpsDurationValueEmitterSetup = sdk.DeviceAction{
 	Name: "UPS Duration emitter setup",
 	Filter: map[string][]string{

--- a/pkg/actions.go
+++ b/pkg/actions.go
@@ -252,6 +252,33 @@ var ActionLockValueEmitterSetup = sdk.DeviceAction{
 	},
 }
 
+// ActionUpsDurationValueEmitterSetup initializes a ValueEmitter for each "duration" type device
+var ActionUpsDurationValueEmitterSetup = sdk.DeviceAction{
+	Name: "UPS Duration emitter setup",
+	Filter: map[string][]string{
+		"type": {"duration"},
+	},
+	Action: func(_ *sdk.Plugin, d *sdk.Device) error {
+		lowerBound, ok := d.Data["min"].(int)
+		if !ok {
+			lowerBound = 0
+		}
+
+		upperBound, ok := d.Data["max"].(int)
+		if !ok {
+			upperBound = 0
+		}
+
+		step, ok := d.Data["step"].(int)
+		if !ok {
+			step = 0
+		}
+
+		emitter := utils.NewValueEmitter(utils.Accumulate).WithLowerBound(lowerBound).WithUpperBound(upperBound).WithStep(step)
+		return utils.SetEmitter(d.GetID(), emitter)
+	},
+}
+
 // ActionPowerValueEmitterSetup initializes a ValueEmitter for each "power" type device.
 var ActionPowerValueEmitterSetup = sdk.DeviceAction{
 	Name: "power value emitter setup",

--- a/pkg/devices/ups.go
+++ b/pkg/devices/ups.go
@@ -8,7 +8,7 @@ import (
 
 // UPS is the handler for the emulated current device(s).
 var UPS = sdk.DeviceHandler{
-	Name:  "duration",
+	Name:  "seconds",
 	Read:  secondsRead,
 	Write: minMaxCurrentWrite,
 }

--- a/pkg/devices/ups.go
+++ b/pkg/devices/ups.go
@@ -1,0 +1,27 @@
+package devices
+
+import (
+	"github.com/vapor-ware/synse-emulator-plugin/pkg/utils"
+	"github.com/vapor-ware/synse-sdk/v2/sdk"
+	"github.com/vapor-ware/synse-sdk/v2/sdk/output"
+)
+
+// UPS is the handler for the emulated current device(s).
+var UPS = sdk.DeviceHandler{
+	Name:  "duration",
+	Read:  secondsRead,
+	Write: minMaxCurrentWrite,
+}
+
+// secondsRead is the read handler for the emulated current device(s).
+func secondsRead(device *sdk.Device) ([]*output.Reading, error) {
+	emitter := utils.GetEmitter(device.GetID())
+	ec, err := output.Seconds.MakeReading(emitter.Next())
+	if err != nil {
+		return nil, err
+	}
+
+	return []*output.Reading{
+		ec,
+	}, nil
+}

--- a/pkg/devices/ups.go
+++ b/pkg/devices/ups.go
@@ -6,14 +6,14 @@ import (
 	"github.com/vapor-ware/synse-sdk/v2/sdk/output"
 )
 
-// UPS is the handler for the emulated current device(s).
+// UPS is the handler for the emulated ups device.
 var UPS = sdk.DeviceHandler{
 	Name:  "seconds",
 	Read:  secondsRead,
 	Write: minMaxCurrentWrite,
 }
 
-// secondsRead is the read handler for the emulated current device(s).
+// secondsRead is the read handler for the emulated ups device.
 func secondsRead(device *sdk.Device) ([]*output.Reading, error) {
 	emitter := utils.GetEmitter(device.GetID())
 	ec, err := output.Seconds.MakeReading(emitter.Next())

--- a/pkg/outputs/outputs.go
+++ b/pkg/outputs/outputs.go
@@ -19,4 +19,14 @@ var (
 		Name: "json",
 		Type: "json",
 	}
+
+	// UPS is the output type for duration readings.
+	UPS = output.Output{
+		Name: "duration",
+		Type: "duration",
+		Unit: &output.Unit{
+			Name:   "seconds",
+			Symbol: "s",
+		},
+	}
 )

--- a/pkg/outputs/outputs.go
+++ b/pkg/outputs/outputs.go
@@ -19,14 +19,4 @@ var (
 		Name: "json",
 		Type: "json",
 	}
-
-	// UPS is the output type for duration readings.
-	UPS = output.Output{
-		Name: "duration",
-		Type: "duration",
-		Unit: &output.Unit{
-			Name:   "seconds",
-			Symbol: "s",
-		},
-	}
 )

--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -19,6 +19,7 @@ func MakePlugin() *sdk.Plugin {
 	err = plugin.RegisterOutputs(
 		&outputs.Airflow,
 		&outputs.JSONOutput,
+		&outputs.UPS,
 	)
 	if err != nil {
 		log.Fatal(err)
@@ -37,6 +38,7 @@ func MakePlugin() *sdk.Plugin {
 		&devices.Humidity,
 		&devices.LED,
 		&devices.Lock,
+		&devices.UPS,
 		&devices.Power,
 		&devices.Pressure,
 		&devices.Temperature,
@@ -60,6 +62,7 @@ func MakePlugin() *sdk.Plugin {
 		&ActionHumidityValueEmitterSetup,
 		&ActionLEDValueEmitterSetup,
 		&ActionLockValueEmitterSetup,
+		&ActionUpsDurationValueEmitterSetup,
 		&ActionPowerValueEmitterSetup,
 		&ActionPressureValueEmitterSetup,
 		&ActionTemperatureValueEmitterSetup,

--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -19,7 +19,6 @@ func MakePlugin() *sdk.Plugin {
 	err = plugin.RegisterOutputs(
 		&outputs.Airflow,
 		&outputs.JSONOutput,
-		&outputs.UPS,
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
There is an existing [snmp emulator](https://github.com/vapor-ware/snmp-emulator), which can be coupled with the [synse-snmp-plugin](https://github.com/vapor-ware/synse-snmp-plugin), but that plugin is a) read-only so we can't trigger power outage events, and b) not deployed to any of the virtual-usa sites.

This PR introduces an emulator for the UPS, which provides the "seconds on battery power" metric that is commonly used in Edge Events to detect a power outage.
