### PR TITLE
chore: [VIO-3019] Update the Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 #
 # Builder Image
 #
-FROM docker.io/vaporio/golang:1.16 as builder
+FROM docker.io/library/debian:stable-slim as builder
+
+RUN apt-get update && apt-get install -y ca-certificates
 
 #
 # Final Image
 #
-FROM docker.io/vaporio/scratch-ish:1.0.0
+FROM scratch
 
 LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.name="vaporio/emulator-plugin" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,32 @@
 #
 # Builder Image
 #
-FROM docker.io/library/debian:stable-slim as builder
+FROM docker.io/library/golang:1.16 as builder
 
 RUN apt-get update && apt-get install -y ca-certificates
+
+RUN useradd -M vaporio
+
+WORKDIR /app
+
+# Download dependencies
+COPY go.* ./
+RUN go mod download
+
+# Copy the project into the builder
+COPY . ./
+
+# Disable dynamic linking. The binary won't work on scratch otherwise
+ENV CGO_ENABLED=0
+
+# Build the binary.
+RUN make build-linux
+
+
+RUN mkdir -p /etc/synse/plugin/config \
+ && mkdir -p /etc/synse/plugin/config \
+ && chown -R vaporio /etc/synse \
+ && chown -R vaporio /app
 
 #
 # Final Image
@@ -16,15 +39,20 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.vendor="Vapor IO"
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
 
 # Build the device configurations directly into the image. This is not
 # generally advised, but is acceptable here since the plugin is merely
 # an emulator and its config is not tied to anything real.
-COPY config/device /etc/synse/plugin/config/device
-COPY config.yml    /etc/synse/plugin/config/config.yml
+COPY --chown=vaporio config/device /etc/synse/plugin/config/device
+COPY --chown=vaporio config.yml    /etc/synse/plugin/config/config.yml
 
 # Copy the executable.
-COPY synse-emulator-plugin ./plugin
+COPY --chown=vaporio --from=builder /app/synse-emulator-plugin /app/plugin
+
 
 EXPOSE 5001
-ENTRYPOINT ["./plugin"]
+
+USER vaporio
+ENTRYPOINT ["/app/plugin"]

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,7 @@ deploy:  ## Run a local deployment of the plugin with Synse Server
 
 .PHONY: docker
 docker:  ## Build the production docker image locally
-	docker build -f Dockerfile \
-		--label "org.label-schema.build-date=${BUILD_DATE}" \
-		--label "org.label-schema.vcs-ref=${GIT_COMMIT}" \
-		--label "org.label-schema.version=${PLUGIN_VERSION}" \
-		-t ${IMAGE_NAME}:latest . || exit
+	env GOLANG_VERSION=${GOLANG_VERSION} goreleaser release --snapshot --clean
 
 .PHONY: docker-dev
 docker-dev:  ## Build the development docker image locally

--- a/README.md
+++ b/README.md
@@ -226,11 +226,21 @@ The plugin can be run in debug mode for additional logging. This is done by:
   docker run -e PLUGIN_DEBUG=true vaporio/emulator-plugin
   ```
 
+### Building
+
+To build the production image locally, you'll first need to [install the goreleaser binary](https://goreleaser.com/install/).
+
+```
+make docker
+```
+
+This will run `goreleaser` to build a local image tagged as the current release, i.e., `docker.io/vaporio/emulator-plugin:3.4.1`.
+
 ### Developing
 
 A [development/debug Dockerfile](Dockerfile.dev) is provided in the project repository to enable
 building image which may be useful when developing or debugging a plugin. Unlike the slim `scratch`-based
-production image, the development image uses an ubuntu base, bringing with it all the standard command line
+production image, the development image uses a Debian base, bringing with it all the standard command line
 tools one would expect. To build a development image:
 
 ```

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -6,21 +6,61 @@
 # Development images contain additional tooling that makes it easier
 # to exec into a contain and dig into whatever may be going on inside.
 #
-FROM docker.io/library/debian:stable-slim as builder
+#
+# Builder Image
+#
+FROM docker.io/library/golang:1.16 as builder
 
-WORKDIR /synse
+RUN apt-get update && apt-get install -y ca-certificates
+
+RUN useradd -M vaporio
+
+WORKDIR /app
+
+# Download dependencies
+COPY go.* ./
+RUN go mod download
+
+# Copy the project into the builder
+COPY . ./
+
+# Disable dynamic linking. The binary won't work on scratch otherwise
+ENV CGO_ENABLED=0
+
+# Build the binary.
+RUN make build-linux
+
+
+RUN mkdir -p /etc/synse/plugin/config \
+ && mkdir -p /etc/synse/plugin/config \
+ && chown -R vaporio /etc/synse \
+ && chown -R vaporio /app
+
+#
+# Final Image
+#
+FROM docker.io/library/debian:stable-slim
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.name="vaporio/emulator-plugin" \
+      org.label-schema.vcs-url="https://github.com/vapor-ware/synse-emulator-plugin" \
+      org.label-schema.vendor="Vapor IO"
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
 
 # Build the device configurations directly into the image. This is not
 # generally advised, but is acceptable here since the plugin is merely
-# an emulator and its config is not tied to anything real. These config
-# defaults may be overridden at run time.
-COPY config/device  /etc/synse/plugin/config/device
-COPY config.yml     /etc/synse/plugin/config/config.yml
+# an emulator and its config is not tied to anything real.
+COPY --chown=vaporio config/device /etc/synse/plugin/config/device
+COPY --chown=vaporio config.yml    /etc/synse/plugin/config/config.yml
 
-# Copy the executable and README information. The executable should be
-# built prior to the image build (see Makefile).
-COPY synse-emulator-plugin ./plugin
-COPY README.md .
+# Copy the executable.
+COPY --chown=vaporio --from=builder /app/synse-emulator-plugin /app/plugin
+
 
 EXPOSE 5001
-ENTRYPOINT ["./plugin"]
+
+USER vaporio
+ENTRYPOINT ["/app/plugin"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -6,8 +6,7 @@
 # Development images contain additional tooling that makes it easier
 # to exec into a contain and dig into whatever may be going on inside.
 #
-
-FROM vaporio/golang:1.16
+FROM docker.io/library/debian:stable-slim as builder
 
 WORKDIR /synse
 


### PR DESCRIPTION
Update the `Dockerfile`s to use the `debian:stable-slim` as the builder, and `scratch` for the final (production) image.

Final image size reduced from 14.5MB to 14MB.