### PR TITLE
Fix workflow release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,5 @@
 name: release
 on:
-  workflow_run:
-    workflows: [build]
-    types:
-      - completed
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
When doing `on.workflow_run` with `on.push`, this represents an `or` condition which is not what we want when doing PRs/pushes.